### PR TITLE
new package: s-nail

### DIFF
--- a/tur-on-device/s-nail/build.sh
+++ b/tur-on-device/s-nail/build.sh
@@ -1,0 +1,52 @@
+TERMUX_PKG_HOMEPAGE="https://www.sdaoden.eu/code.html#s-nail"
+TERMUX_PKG_DESCRIPTION="Portable mailx(1) with MIME and Maildir support"
+TERMUX_PKG_LICENSE="ISC, BSD"
+TERMUX_PKG_LICENSE_FILE="COPYING"
+TERMUX_PKG_MAINTAINER="@flosnvjx"
+TERMUX_PKG_VERSION="14.9.24"
+TERMUX_PKG_SRCURL="https://github.com/sdaoden/s-mailx/archive/refs/tags/v$TERMUX_PKG_VERSION.tar.gz"
+TERMUX_PKG_SHA256=b8b516b5b8d77ae21ebad88c6a202c1c931719c5e646d1f3f8070c023cf33ed6
+TERMUX_PKG_DEPENDS="libidn2, libiconv, openssl, ncurses"
+TERMUX_PKG_BUILD_DEPENDS="getconf"
+TERMUX_PKG_RECOMMENDS="ed, vi, mime-support"
+TERMUX_PKG_PROVIDES=mailx
+TERMUX_PKG_CONFLICTS=mailx
+TERMUX_PKG_BUILD_IN_SRC=true
+TERMUX_PKG_MAKE_INSTALL_TARGET="DESTDIR=/ install"
+## Use a dummy DESTDIR to avoid installing uninstall.sh to PREFIX/bin.
+
+termux_step_configure() {
+	make \
+		VAL_PREFIX=$TERMUX_PREFIX \
+		C_INCLUDE_PATH="$TERMUX_PREFIX/include" \
+		LD_LIBRARY_PATH="$TERMUX_PREFIX/lib" \
+		OPT_AUTOCC=no \
+		OPT_CROSS_BUILD=yes \
+		EXTRA_CFLAGS="$CPPFLAGS" \
+		VERBOSE=yes \
+		VAL_MAIL="$TERMUX_PREFIX"/var/spool/mail \
+		VAL_MTA="$TERMUX_PREFIX"/bin/sendmail \
+		VAL_SHELL="$TERMUX_PREFIX"/bin/sh \
+		VAL_TMPDIR="$TERMUX_PREFIX"/tmp \
+		VAL_PAGER=less \
+		VAL_MIME_TYPES_SYS="$TERMUX_PREFIX"/etc/mime.types \
+		VAL_MAILCAPS="$TERMUX_ANDROID_HOME/.mailcap:$TERMUX_PREFIX/etc/mailcap" \
+		VAL_RANDOM="tls,libgetrandom,sysgetrandom,urandom,builtin" \
+		OPT_NET=yes \
+		OPT_USE_PKGSYS=no \
+		OPT_TLS_ALL_ALGORITHMS=no \
+		OPT_ALWAYS_UNICODE_LOCALE=yes \
+		OPT_DOTLOCK=no \
+		OPT_GSSAPI=no \
+		OPT_SPAM_FILTER=no \
+		config
+	printf '%s\n' "make config. done."
+}
+
+termux_step_post_make_install() {
+	mkdir -vp "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME"
+	ln -vs "$TERMUX_PREFIX/bin/s-nail" "$TERMUX_PREFIX/bin/mailx"
+	ln -vs "$TERMUX_PREFIX/share/man/man1/"{s-nail,mailx}.1.gz
+	cp -v README NEWS THANKS -t "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME"
+	mv -vt "$TERMUX_PREFIX/share/doc/$TERMUX_PKG_NAME" "$TERMUX_PREFIX/etc/$TERMUX_PKG_NAME.rc"
+}

--- a/tur-on-device/s-nail/mblen.patch
+++ b/tur-on-device/s-nail/mblen.patch
@@ -1,0 +1,13 @@
+diff --git a/src/mx/ui-str.c b/src/mx/ui-str.c
+index 8ef4e48..bc8a99c 100644
+--- a/src/mx/ui-str.c
++++ b/src/mx/ui-str.c
+@@ -54,6 +54,8 @@
+ /* TODO fake */
+ #include "su/code-in.h"
+ 
++int mblen(const char *s, size_t n) {return mbtowc(0, s, n);}
++
+ #ifdef mx_HAVE_NATCH_CHAR
+ struct a_uis_bidi_info{
+    struct str bi_start; /* Start of (possibly) bidirectional text */

--- a/tur-on-device/s-nail/stub-wchar-test.patch
+++ b/tur-on-device/s-nail/stub-wchar-test.patch
@@ -1,0 +1,37 @@
+--- a/mk/make-config.sh	2022-03-26 23:28:51.000000000 +0800
++++ b/mk/make-config.sh	2022-09-23 12:21:33.954446786 +0800
+@@ -2239,29 +2239,19 @@
+ if [ -n "${have_setlocale}" ]; then
+    link_check c90amend1 'ISO/IEC 9899:1990/Amendment 1:1995' \
+       '#define mx_HAVE_C90AMEND1' << \!
+-#include <limits.h>
+-#include <stdlib.h>
+-#include <wchar.h>
+-#include <wctype.h>
++#include <locale.h>
+ int main(void){
+-   char mbb[MB_LEN_MAX + 1];
+-   wchar_t wc;
+-
+-   iswprint(L'c');
+-   towupper(L'c');
+-   mbtowc(&wc, "x", 1);
+-   mbrtowc(&wc, "x", 1, NULL);
+-   wctomb(mbb, wc);
+-   return (mblen("\0", 1) == 0);
++   setlocale(LC_ALL, "");
++   return 0;
+ }
+ !
+    [ -n "${have_c90amend1}" ] && OPT_MULTIBYTE_CHARSETS=1
+ 
+    if [ -n "${have_c90amend1}" ]; then
+       link_check wcwidth 'wcwidth(3)' '#define mx_HAVE_WCWIDTH' << \!
+-#include <wchar.h>
++#include <locale.h>
+ int main(void){
+-   wcwidth(L'c');
++   setlocale(LC_ALL, "");
+    return 0;
+ }
+ !


### PR DESCRIPTION
what: this one provides `mailx(1)` and has extra features like generating mime attached emails from stdin, which is useful in shell pipeline.

why: the handcrafted build scripts of s-nail does not work well with official buildenv, when build in official buildenv and termux arch is same as host arch ($TERMUX_ARCH == $(uname -m)), `/usr/bin/awk` during `make config` will report same error as in commit message of https://github.com/termux/termux-packages/commit/acef41f796826e2deeab572f1e5544797a31abe6, hence build it on device instead.

Only for reference: [previous tur build failure log](https://github.com/termux-user-repository/tur/actions/runs/3110730338/jobs/5042213494#step:7:648), if building with normal buildenv, uuencoding the `TERMUX_PKG_SRCDIR/.obj` directory then we can see `/usr/bin/awk` failed in similar error in aforementioned commit message.